### PR TITLE
For chat, clear the annoucement option after sending.

### DIFF
--- a/huntserver/static/huntserver/chat.js
+++ b/huntserver/static/huntserver/chat.js
@@ -36,6 +36,7 @@ $(document).ready(function() {
         last_pk = response['last_pk'];
       });
     $('#messagebox').val('');
+    $('#announce_checkbox').prop('checked', false);
   }
 
   var get_posts = function() {


### PR DESCRIPTION
Resolves #88.